### PR TITLE
Scaffold Concrete monorepo with tokens, UI primitives, and Next docs app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
-# dependencies
-node_modules/
-
-# environment
-.env
-
-# macOS
+node_modules
+.next
+dist
+bun.lock
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Concrete
+
+Concrete is Rubric Labs' agentic-first design system monorepo.
+
+## Workspaces
+
+- `packages/tokens` foundation tokens and density metadata
+- `packages/ui` typed React primitives
+- `apps/site` Next.js documentation and renderer
+
+## Commands
+
+- `bun install`
+- `bun run dev`
+- `bun run check`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: concrete-system-intelligence
+description: Implementation and usage guidance for the Concrete monorepo, including density modes, component rendering routes, and package boundaries.
+user-invocable: true
+---
+
+Concrete is organized as a Bun workspace monorepo.
+
+- `packages/tokens`: canonical foundations as CSS variables and typed density metadata.
+- `packages/ui`: typed React primitives and composed components.
+- `apps/site`: Next.js docs site and component rendering endpoints.
+
+Density modes:
+- `product`: highest information density
+- `generative`: focused operational density
+- `editorial`: most readable and spacious
+- `educational`: low-fidelity instructional framing
+
+Render routes:
+- `/components/[name]`: interactive component state rendering from query params
+- `/components/[name].jpg`: deterministic image rendering endpoint for snapshots
+
+Workflow:
+1. Add or adjust tokens in `@concrete/tokens` first.
+2. Keep primitives in `@concrete/ui` narrow and deterministic.
+3. Surface usage in `apps/site` examples.
+4. Run `bun run check` before commits.

--- a/apps/site/app/components/[name].jpg/route.tsx
+++ b/apps/site/app/components/[name].jpg/route.tsx
@@ -1,0 +1,50 @@
+import { ImageResponse } from 'next/og';
+
+import { componentNames, parseState } from '@/lib/component-state';
+
+export const runtime = 'edge';
+
+export async function GET(request: Request, context: { params: Promise<Record<string, string>> }) {
+  const name = (await context.params).name;
+  if (!name || !componentNames.includes(name as (typeof componentNames)[number])) {
+    return new Response('Not found', { status: 404 });
+  }
+  const url = new URL(request.url);
+  const state = parseState(Object.fromEntries(url.searchParams));
+  const content =
+    name === 'button'
+      ? state.label
+      : name === 'input'
+        ? state.value
+        : name === 'badge'
+          ? `${state.signal} · ${state.label}`
+          : state.label;
+
+  const image = new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        background: '#f7f8fa',
+        color: '#0a0b0f',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        border: '1px solid #d7d9e0',
+        borderRadius: '20px',
+        fontFamily: 'Inter',
+        fontSize: 42,
+      }}
+    >
+      {name} · {content}
+    </div>,
+    { width: 1200, height: 630 }
+  );
+
+  return new Response(image.body, {
+    headers: {
+      'content-type': 'image/png',
+      'cache-control': 'public, max-age=3600',
+    },
+  });
+}

--- a/apps/site/app/components/[name]/page.tsx
+++ b/apps/site/app/components/[name]/page.tsx
@@ -1,0 +1,38 @@
+import { Badge, Button, Card, DensityFrame, Input, Stack } from '@concrete/ui';
+import { notFound } from 'next/navigation';
+
+import { componentNames, parseState } from '@/lib/component-state';
+
+export default async function ComponentPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ name: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { name } = await params;
+  if (!componentNames.includes(name as (typeof componentNames)[number])) {
+    notFound();
+  }
+  const state = parseState(await searchParams);
+  return (
+    <DensityFrame density={state.density}>
+      <Card>
+        <Stack>
+          {name === 'button' && (
+            <Button variant={state.variant === 'secondary' ? 'secondary' : 'primary'}>
+              {state.label}
+            </Button>
+          )}
+          {name === 'input' && <Input defaultValue={state.value} />}
+          {name === 'badge' && <Badge signal={state.signal}>{state.label}</Badge>}
+          {name === 'card' && (
+            <Card>
+              <p>{state.label}</p>
+            </Card>
+          )}
+        </Stack>
+      </Card>
+    </DensityFrame>
+  );
+}

--- a/apps/site/app/components/page.tsx
+++ b/apps/site/app/components/page.tsx
@@ -1,0 +1,22 @@
+import { componentNames } from '@/lib/component-state';
+
+export default function ComponentsPage() {
+  return (
+    <>
+      <header className="page-header">
+        <p className="concrete-label">Components</p>
+        <h1>Deterministic rendering</h1>
+        <p>Each component has a query-driven route and an image endpoint for snapshots.</p>
+      </header>
+      <div className="component-grid">
+        {componentNames.map((name) => (
+          <article className="concrete-card preview" key={name}>
+            <h3>{name}</h3>
+            <a href={`/components/${name}?density=product`}>Interactive route</a>
+            <a href={`/components/${name}.jpg?density=product`}>Image route</a>
+          </article>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/site/app/foundations/page.tsx
+++ b/apps/site/app/foundations/page.tsx
@@ -1,0 +1,34 @@
+const swatches = [
+  ['--canvas', 'Canvas'],
+  ['--surface', 'Surface'],
+  ['--ink-9', 'Ink 9'],
+  ['--ink-5', 'Ink 5'],
+  ['--sky', 'Sky'],
+  ['--terminal', 'Terminal'],
+  ['--ultra', 'Ultra'],
+  ['--error', 'Error'],
+] as const;
+
+export default function FoundationsPage() {
+  return (
+    <>
+      <header className="page-header">
+        <p className="concrete-label">Foundations</p>
+        <h1>Tokens</h1>
+      </header>
+      <section className="grid-2">
+        {swatches.map(([token, label]) => (
+          <article className="concrete-card" key={token}>
+            <div className="token-row">
+              <span className="swatch" style={{ background: `var(${token})` }} />
+              <div>
+                <div>{label}</div>
+                <code>{token}</code>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+    </>
+  );
+}

--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -1,0 +1,63 @@
+@import "@concrete/ui/styles.css";
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--s-8);
+}
+h1,
+h2,
+h3,
+h4,
+p {
+  margin: 0;
+}
+.page-header {
+  display: grid;
+  gap: var(--s-3);
+  margin-bottom: var(--s-8);
+}
+.display-title {
+  font-family: var(--font-display);
+  font-size: clamp(40px, 6vw, 72px);
+  line-height: var(--lh-tight);
+  letter-spacing: var(--tr-display);
+  color: var(--fg-strong);
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--s-4);
+}
+.nav {
+  display: flex;
+  gap: var(--s-4);
+  padding: var(--s-4) 0;
+  border-bottom: 1px solid var(--border-soft);
+  margin-bottom: var(--s-8);
+  font-size: var(--t-13);
+}
+.token-row {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+}
+.swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-3);
+  border: 1px solid var(--border);
+}
+.component-grid {
+  display: grid;
+  gap: var(--s-4);
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+.preview {
+  display: grid;
+  gap: var(--s-3);
+}

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+import './globals.css';
+
+const nav = [
+  { href: '/', label: 'Concrete' },
+  { href: '/foundations', label: 'Foundations' },
+  { href: '/primitives', label: 'Primitives' },
+  { href: '/components', label: 'Components' },
+];
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <main>
+          <nav className="nav">
+            {nav.map((item) => (
+              <a href={item.href} key={item.href}>
+                {item.label}
+              </a>
+            ))}
+          </nav>
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -1,0 +1,40 @@
+import { Badge, Button, Card, DensityFrame, Input, Label, Stack } from '@concrete/ui';
+
+export default function HomePage() {
+  return (
+    <>
+      <header className="page-header">
+        <p className="concrete-label">Rubric Labs Design System</p>
+        <h1 className="display-title">Concrete</h1>
+        <p>
+          An agentic-first system with four pressure modes that move from editorial clarity to
+          product density without losing typographic and semantic integrity.
+        </p>
+      </header>
+      <DensityFrame density="generative">
+        <div className="grid-2">
+          <Card>
+            <Stack>
+              <Label>Mission</Label>
+              <p>
+                Single language across editorial publishing, AI interfaces, and dense dashboards.
+              </p>
+              <Button>Read the system</Button>
+            </Stack>
+          </Card>
+          <Card>
+            <Stack>
+              <Label>Signals</Label>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <Badge signal="terminal">Live</Badge>
+                <Badge signal="ultra">Featured</Badge>
+                <Badge signal="error">Risk</Badge>
+              </div>
+              <Input defaultValue="context-architecture" />
+            </Stack>
+          </Card>
+        </div>
+      </DensityFrame>
+    </>
+  );
+}

--- a/apps/site/app/primitives/page.tsx
+++ b/apps/site/app/primitives/page.tsx
@@ -1,0 +1,28 @@
+import { Badge, Button, Card, DensityFrame, Input, Label, Stack } from '@concrete/ui';
+
+const densities = ['product', 'generative', 'editorial', 'educational'] as const;
+
+export default function PrimitivesPage() {
+  return (
+    <>
+      <header className="page-header">
+        <p className="concrete-label">Primitives</p>
+        <h1>Core atoms</h1>
+      </header>
+      <div className="component-grid">
+        {densities.map((density) => (
+          <Card key={density}>
+            <DensityFrame density={density}>
+              <Stack>
+                <Label>{density}</Label>
+                <Button>Run</Button>
+                <Input defaultValue="query context" />
+                <Badge signal="terminal">active</Badge>
+              </Stack>
+            </DensityFrame>
+          </Card>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/site/lib/component-state.ts
+++ b/apps/site/lib/component-state.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const componentNames = ['button', 'input', 'badge', 'card'] as const;
+
+export type ComponentName = (typeof componentNames)[number];
+
+const densitySchema = z
+  .enum(['product', 'generative', 'editorial', 'educational'])
+  .default('product');
+
+export const componentStateSchema = z.object({
+  density: densitySchema,
+  variant: z.string().default('primary'),
+  label: z.string().default('Execute task'),
+  value: z.string().default('agent-memory-v2'),
+  signal: z.enum(['terminal', 'ultra', 'error']).default('terminal'),
+});
+
+export type ComponentState = z.infer<typeof componentStateSchema>;
+
+export function parseState(
+  searchParams: Record<string, string | string[] | undefined>
+): ComponentState {
+  const flattened = Object.fromEntries(
+    Object.entries(searchParams).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value[0] : value,
+    ])
+  );
+  return componentStateSchema.parse(flattened);
+}

--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  transpilePackages: ['@concrete/ui', '@concrete/tokens'],
+};
+
+export default nextConfig;

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@concrete/site",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@concrete/tokens": "workspace:*",
+    "@concrete/ui": "workspace:*",
+    "next": "^16.0.1",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2"
+  }
+}

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@concrete/ui": ["../../packages/ui/src/index.tsx"],
+      "@concrete/ui/styles.css": ["../../packages/ui/src/styles.css"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "incremental": true,
+    "noEmit": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "package.json",
+      "biome.json",
+      "tsconfig.base.json",
+      "README.md",
+      "SKILL.md",
+      "apps/**",
+      "packages/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "useNodejsImportProtocol": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "es5"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "concrete",
+  "private": true,
+  "packageManager": "bun@1.2.15",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "bun --filter @concrete/site dev",
+    "build": "bun run build:packages && bun --filter @concrete/site build",
+    "build:packages": "bun --filter @concrete/tokens build && bun --filter @concrete/ui build",
+    "typecheck": "bun --filter '*' typecheck",
+    "lint": "biome check .",
+    "format": "biome format --write .",
+    "check": "bun run lint && bun run typecheck && bun run build"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@concrete/tokens",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/tokens/src/concrete.css
+++ b/packages/tokens/src/concrete.css
@@ -1,0 +1,118 @@
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..800,50..100,0..1&family=JetBrains+Mono:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap");
+
+:root {
+  --canvas: #f7f8fa;
+  --surface: #ffffff;
+  --raised: #fcfcfd;
+  --sunken: #f1f2f5;
+  --mist: #eaecf0;
+
+  --ink-9: #0a0b0f;
+  --ink-8: #16171c;
+  --ink-7: #22242b;
+  --ink-6: #3a3c45;
+  --ink-5: #5a5d68;
+  --ink-4: #878a95;
+  --ink-3: #b4b7c0;
+  --ink-2: #d7d9e0;
+  --ink-1: #e8eaee;
+
+  --fg-strong: var(--ink-9);
+  --fg-body: var(--ink-7);
+  --fg: var(--ink-6);
+  --fg-muted: var(--ink-5);
+  --fg-soft: var(--ink-4);
+
+  --border: var(--ink-2);
+  --border-hi: var(--ink-3);
+  --border-soft: var(--ink-1);
+
+  --sky-1: #eef3fb;
+  --sky-2: #d9e6f8;
+  --sky-3: #a9c6ef;
+  --sky-4: #4e8bde;
+  --sky: #1f6fd4;
+  --sky-hi: #0f4e9e;
+  --sky-ring: rgb(31 111 212 / 28%);
+
+  --terminal-1: #f2fbf5;
+  --terminal: #16c46a;
+  --terminal-hi: #15803d;
+  --terminal-ring: rgb(22 196 106 / 22%);
+
+  --ultra-1: #f6f5ff;
+  --ultra: #6b5bff;
+  --ultra-hi: #4a3de0;
+
+  --error-1: #fef3f3;
+  --error: #f03a3a;
+  --error-hi: #b91c1c;
+
+  --font-sans: "Plus Jakarta Sans", -apple-system, blinkmacsystemfont, system-ui, sans-serif;
+  --font-display: "Fraunces", "Iowan Old Style", "Apple Garamond", georgia, serif;
+  --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, menlo, monospace;
+
+  --t-11: 11px;
+  --t-12: 12px;
+  --t-13: 13px;
+  --t-14: 14px;
+  --t-15: 15px;
+  --t-17: 17px;
+  --t-20: 20px;
+  --t-24: 24px;
+  --t-28: 28px;
+  --t-32: 32px;
+  --t-40: 40px;
+  --t-48: 48px;
+
+  --lh-tight: 1.02;
+  --lh-snug: 1.18;
+  --lh-normal: 1.45;
+
+  --tr-display: -0.032em;
+  --tr-tight: -0.014em;
+  --tr-caps: 0.1em;
+
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-8: 32px;
+  --s-10: 40px;
+  --s-12: 48px;
+
+  --r-2: 4px;
+  --r-3: 6px;
+  --r-4: 10px;
+  --r-5: 14px;
+  --r-pill: 9999px;
+
+  --shadow-1: 0 1px 2px rgb(10 11 15 / 4%);
+  --shadow-2: 0 2px 8px rgb(10 11 15 / 6%), 0 1px 2px rgb(10 11 15 / 4%);
+  --shadow-3: 0 12px 32px rgb(10 11 15 / 10%), 0 2px 6px rgb(10 11 15 / 5%);
+  --ring-focus: 0 0 0 3px var(--sky-ring);
+
+  --ease: cubic-bezier(0.2, 0, 0, 1);
+  --dur: 180ms;
+
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+body {
+  background: var(--canvas);
+  color: var(--fg-body);
+  font-family: var(--font-sans);
+  font-size: var(--t-15);
+  line-height: var(--lh-normal);
+  font-feature-settings: "ss01", "cv01", "tnum";
+}

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,0 +1,10 @@
+export const densities = ['product', 'generative', 'editorial', 'educational'] as const;
+
+export type Density = (typeof densities)[number];
+
+export const densityClassName: Record<Density, string> = {
+  product: 'density-product',
+  generative: 'density-generative',
+  editorial: 'density-editorial',
+  educational: 'density-educational',
+};

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@concrete/ui",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.tsx",
+  "types": "./src/index.tsx",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/index.tsx",
+      "default": "./src/index.tsx"
+    },
+    "./styles.css": "./src/styles.css"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "dependencies": {
+    "@concrete/tokens": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,0 +1,65 @@
+import type { Density } from '@concrete/tokens';
+import { densityClassName } from '@concrete/tokens';
+import type { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
+
+export { type Density, densities } from '@concrete/tokens';
+
+export function DensityFrame({
+  density,
+  className,
+  children,
+}: PropsWithChildren<{ density: Density; className?: string }>) {
+  return (
+    <div className={[densityClassName[density], className].filter(Boolean).join(' ')}>
+      {children}
+    </div>
+  );
+}
+
+export function Stack(props: ComponentPropsWithoutRef<'div'>) {
+  return (
+    <div {...props} className={['concrete-stack', props.className].filter(Boolean).join(' ')} />
+  );
+}
+
+export function Card(props: ComponentPropsWithoutRef<'section'>) {
+  return (
+    <section {...props} className={['concrete-card', props.className].filter(Boolean).join(' ')} />
+  );
+}
+
+export function Label(props: ComponentPropsWithoutRef<'p'>) {
+  return <p {...props} className={['concrete-label', props.className].filter(Boolean).join(' ')} />;
+}
+
+export function Button({
+  variant = 'primary',
+  ...props
+}: ComponentPropsWithoutRef<'button'> & { variant?: 'primary' | 'secondary' }) {
+  return (
+    <button
+      {...props}
+      className={['concrete-button', props.className].filter(Boolean).join(' ')}
+      data-variant={variant}
+    />
+  );
+}
+
+export function Input(props: ComponentPropsWithoutRef<'input'>) {
+  return (
+    <input {...props} className={['concrete-input', props.className].filter(Boolean).join(' ')} />
+  );
+}
+
+export function Badge({
+  signal = 'terminal',
+  ...props
+}: ComponentPropsWithoutRef<'span'> & { signal?: 'terminal' | 'ultra' | 'error' }) {
+  return (
+    <span
+      {...props}
+      className={['concrete-badge', props.className].filter(Boolean).join(' ')}
+      data-signal={signal}
+    />
+  );
+}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,0 +1,101 @@
+@import "@concrete/tokens/src/concrete.css";
+
+.density-product {
+  --row-height: 28px;
+  --pad: var(--s-2);
+  --gap: var(--s-2);
+}
+.density-generative {
+  --row-height: 32px;
+  --pad: var(--s-3);
+  --gap: var(--s-3);
+}
+.density-editorial {
+  --row-height: 40px;
+  --pad: var(--s-5);
+  --gap: var(--s-4);
+}
+.density-educational {
+  --row-height: 36px;
+  --pad: var(--s-4);
+  --gap: var(--s-4);
+}
+
+.concrete-stack {
+  display: grid;
+  gap: var(--gap, var(--s-3));
+}
+.concrete-card {
+  border: 1px solid var(--border);
+  border-radius: var(--r-4);
+  background: var(--surface);
+  box-shadow: var(--shadow-1);
+  padding: var(--pad, var(--s-4));
+}
+.concrete-label {
+  font-size: var(--t-11);
+  font-weight: 700;
+  letter-spacing: var(--tr-caps);
+  text-transform: uppercase;
+  color: var(--fg-soft);
+}
+.concrete-button {
+  height: var(--row-height, 28px);
+  border-radius: var(--r-3);
+  border: 1px solid var(--ink-9);
+  background: var(--ink-9);
+  color: white;
+  font: inherit;
+  font-size: var(--t-13);
+  font-weight: 600;
+  padding: 0 var(--s-3);
+  transition: all var(--dur) var(--ease);
+}
+.concrete-button:hover {
+  background: var(--ink-8);
+}
+.concrete-button[data-variant="secondary"] {
+  border-color: var(--border);
+  background: var(--surface);
+  color: var(--fg-body);
+}
+.concrete-input {
+  height: var(--row-height, 28px);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  background: var(--surface);
+  padding: 0 var(--s-3);
+  font: inherit;
+  font-size: var(--t-13);
+  color: var(--fg-body);
+}
+.concrete-input:focus-visible,
+.concrete-button:focus-visible {
+  outline: 0;
+  box-shadow: var(--ring-focus);
+}
+.concrete-badge {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  font-size: var(--t-11);
+  height: 20px;
+  padding: 0 var(--s-2);
+  gap: 6px;
+}
+.concrete-badge[data-signal="terminal"] {
+  border-color: var(--terminal);
+  color: var(--terminal-hi);
+  background: var(--terminal-1);
+}
+.concrete-badge[data-signal="ultra"] {
+  border-color: var(--ultra);
+  color: var(--ultra-hi);
+  background: var(--ultra-1);
+}
+.concrete-badge[data-signal="error"] {
+  border-color: var(--error);
+  color: var(--error-hi);
+  background: var(--error-1);
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "baseUrl": "."
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": false
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, production-ready monorepo for the Concrete design system that supports agentic-first density modes and deterministic component rendering. 
- Establish a single source of truth for foundations (tokens) and a narrow, well-typed React primitives surface to avoid long-tail customization and reduce future tech debt. 
- Ship a small Next.js documentation app that demonstrates primitives, foundations, and programmatic component snapshots for CI-driven visuals. 

### Description
- Add Bun workspace scaffold and developer scripts in the root `package.json` plus shared TypeScript base in `tsconfig.base.json` and Biome config in `biome.json`. 
- Create `@concrete/tokens` with `src/concrete.css` (canonical CSS variables: ink ramp, surfaces, sky, signals, spacing, radii, shadows, motion, fonts) and typed density metadata in `src/index.ts`. 
- Create `@concrete/ui` with a focused primitives surface (`DensityFrame`, `Stack`, `Card`, `Label`, `Button`, `Input`, `Badge`) and `src/styles.css` that imports the tokens; packages expose a compact API and density-aware CSS classes. 
- Add Next.js docs app `@concrete/site` with four main pages (landing, foundations, primitives, components), a shared layout/globals, a Zod-powered `apps/site/lib/component-state.ts` parser, per-component interactive routes at `/components/[name]`, and a deterministic image endpoint at `/components/[name].jpg` for programmatic snapshots. 
- Add project-level `SKILL.md` (implementation guidance) and `README.md` (quick start). 

### Testing
- Ran `bun install` which completed successfully. 
- Ran `bun run format` (Biome) to apply formatting fixes and normalize files. 
- Ran the full check via `bun run check` (Biome lint + workspace typecheck + package builds + Next build), which completed successfully after addressing initial type/lint issues and formatting fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0bffb1f0832b906e34d99084e16b)